### PR TITLE
clarify terraform .13 change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 ### 2.0.0
 
-* **Terraform 0.13**
+* **Breaking** - Terraform 0.13 is now required.
 
 * Readme Updates
 * Reordering Variables alphabetically [airmonitor]


### PR DESCRIPTION
I saw Terraform 0.13 and thought it meant that support for .13 was added, when in actuality it meant that .13 was now required.

Relevant change: https://github.com/USSBA/terraform-aws-inspector/commit/6d3c4213a09e5b9cac0fd7fd5d0d4ec623ae77f7#diff-dfd5848fa77a04d0343891fe859286cc210473d10f0e62c7f99f0d5ecf1a9927

`required_version = "~> 0.13.0"`