### PR TITLE
Allow ARN for rulesets to be passed as a parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Note: this module currently does not support the customization of assessment tar
 * `ruleset_cis` - Default `true`; Includes the CIS Benchmarks [ruleset](https://docs.aws.amazon.com/inspector/latest/userguide/inspector_rule-packages.html) in the Inspector assessment.
 * `ruleset_security_best_practices` - Default `true`; Includes the AWS Security Best Practices [ruleset](https://docs.aws.amazon.com/inspector/latest/userguide/inspector_rule-packages.html) in the Inspector assessment.
 * `ruleset_network_reachability` - Default `true`; Includes the Network Reachability [ruleset](https://docs.aws.amazon.com/inspector/latest/userguide/inspector_rule-packages.html) in the Inspector assessment.
+* `ruleset_cve_arn` - Default `arn:aws:inspector:us-east-1:316112463485:rulespackage/0-gEjTy7T7`; ARN for Common Vulnerabilities and Exposures [Ruleset](https://docs.aws.amazon.com/inspector/latest/userguide/inspector_rules-arns.html)
+* `ruleset_cis_arn` - Default `arn:aws:inspector:us-east-1:316112463485:rulespackage/0-rExsr2X8`; ARN for CIS Operating System Security Configuration Benchmarks [ruleset](https://docs.aws.amazon.com/inspector/latest/userguide/inspector_rules-arns.html)
+* `ruleset_network_reachability_arn` - Default `arn:aws:inspector:us-east-1:316112463485:rulespackage/0-PmNV0Tcd`; ARN for AWS Network Reachability [ruleset](https://docs.aws.amazon.com/inspector/latest/userguide/inspector_rules-arns.html)
+* `ruleset_security_best_practices_arn` - Default `arn:aws:inspector:us-east-1:316112463485:rulespackage/0-R01qwB5Q`; ARN for AWS Security Best Practices [ruleset](https://docs.aws.amazon.com/inspector/latest/userguide/inspector_rules-arns.html)
 
 ### Simple Example
 
@@ -56,6 +60,19 @@ module "my-inspector-deployment" {
   ruleset_cis                     = false
   ruleset_security_best_practices = true
   ruleset_network_reachability    = false
+}
+```
+An example showcasing the ability to pass ruleset ARN's for use in `eu-west-1` region.
+
+```terraform
+module "my-inspector-deployment" {
+  source                              = "USSBA/inspector/aws"
+  version                             = "~> 3.0"
+  name_prefix                         = "my-inspector"
+  ruleset_cis_arn                     = "arn:aws:inspector:eu-west-1:357557129151:rulespackage/0-sJBhCr0F"
+  ruleset_cve_arn                     = "arn:aws:inspector:eu-west-1:357557129151:rulespackage/0-ubA5XvBh"
+  ruleset_network_reachability_arn    = "arn:aws:inspector:eu-west-1:357557129151:rulespackage/0-SPzU33xe"
+  ruleset_security_best_practices_arn = "arn:aws:inspector:eu-west-1:357557129151:rulespackage/0-SnojL3Z6"
 }
 ```
 

--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,10 @@
 locals {
   scheduled_count = var.enable_scheduled_event ? 1 : 0
   assessment_ruleset = compact([
-    var.ruleset_cis ? "arn:aws:inspector:us-east-1:316112463485:rulespackage/0-rExsr2X8" : "",
-    var.ruleset_cve ? "arn:aws:inspector:us-east-1:316112463485:rulespackage/0-gEjTy7T7" : "",
-    var.ruleset_network_reachability ? "arn:aws:inspector:us-east-1:316112463485:rulespackage/0-PmNV0Tcd" : "",
-    var.ruleset_security_best_practices ? "arn:aws:inspector:us-east-1:316112463485:rulespackage/0-R01qwB5Q" : "",
+    var.ruleset_cis ? var.ruleset_cis_arn : "",
+    var.ruleset_cve ? var.ruleset_cve_arn : "",
+    var.ruleset_network_reachability ? var.ruleset_network_reachability_arn : "",
+    var.ruleset_security_best_practices ? var.ruleset_security_best_practices_arn : "",
     ]
   )
 }

--- a/variables.tf
+++ b/variables.tf
@@ -33,6 +33,26 @@ variable "ruleset_security_best_practices" {
   description = "Enable AWS Security Best Practices Ruleset"
   default     = true
 }
+variable "ruleset_cve_arn" {
+  type        = string
+  description = "ARN for Common Vulnerabilities and Exposures Ruleset: https://docs.aws.amazon.com/inspector/latest/userguide/inspector_rules-arns.html"
+  default     = "arn:aws:inspector:us-east-1:316112463485:rulespackage/0-gEjTy7T7"
+}
+variable "ruleset_cis_arn" {
+  type        = string
+  description = "ARN for CIS Operating System Security Configuration Benchmarks Ruleset: https://docs.aws.amazon.com/inspector/latest/userguide/inspector_rules-arns.html"
+  default     = "arn:aws:inspector:us-east-1:316112463485:rulespackage/0-rExsr2X8"
+}
+variable "ruleset_network_reachability_arn" {
+  type        = string
+  description = "ARN for AWS Network Reachability Ruleset: https://docs.aws.amazon.com/inspector/latest/userguide/inspector_rules-arns.html"
+  default     = "arn:aws:inspector:us-east-1:316112463485:rulespackage/0-PmNV0Tcd"
+}
+variable "ruleset_security_best_practices_arn" {
+  type        = string
+  description = "ARN for AWS Security Best Practices Ruleset: https://docs.aws.amazon.com/inspector/latest/userguide/inspector_rules-arns.html"
+  default     = "arn:aws:inspector:us-east-1:316112463485:rulespackage/0-R01qwB5Q"
+}
 variable "schedule_expression" {
   type        = string
   description = "AWS Schedule Expression: https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html"


### PR DESCRIPTION
This PR allows ARN for CIS, CVE, Network reachability & Security best practices rulesets to be passed as a module parameter making it easier to use in regions other than us-east-1.

The variables have default set to us-east-1 ruleset ARN's, so it shouldn't be a breaking change for existing users.